### PR TITLE
Update CMVP search URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Module details:
 	build:    	3.0.9
 
 Locate applicable CMVP certificates at
-    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL+FIPS+Provider&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.9
+    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.9
 ```
 
 Example output on Ubuntu Pro FIPS instance:
@@ -139,5 +139,5 @@ Module details:
 	build:    	3.0.5-0ubuntu0.1+Fips2.1
 
 Locate applicable CMVP certificates at
-    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=Ubuntu+22.04+OpenSSL+Cryptographic+Module&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.5
+    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.5
 ```

--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -156,12 +156,8 @@ static void print_module_version(void) {
         if (OSSL_PARAM_modified(params + 2))
                 fprintf(stderr, "\t%-10s\t%s\n", "build:", build);
 
-        char * encoded_name = (char*) malloc(strlen(name)+1*sizeof(char));
-        snprintf(encoded_name, strlen(name)+1, "%s", name);
-        for (int i = 0; i<strlen(encoded_name); i++) if (encoded_name[i] == ' ') encoded_name[i] = '+';
-
         fprintf(stderr, "\nLocate applicable CMVP certificates at\n");
-        fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=%s&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=%.5s\n", encoded_name, vers);
+        fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=%.5s\n", vers);
 
         return;
  err:


### PR DESCRIPTION
Rebranded OpenSSL certificates may have the module name, not match the one
encoded in the provider. Search for "OpenSSL" string + version, which brings up
more accurate results with the rebranded certificates.

New search URL is:
https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.9

Old search URL is:
https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL+FIPS+Provider&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.9
