### PR TITLE
Print public API version information

### DIFF
--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -22,6 +22,7 @@
 #include <openssl/evp.h>
 #include <openssl/provider.h>
 #include <openssl/self_test.h>
+#include <openssl/opensslv.h>
 
 struct test_ {
 	const char *name;
@@ -131,12 +132,22 @@ static int self_test_events(const OSSL_PARAM params[], void *arg)
         return false;
 }
 
+static void print_base_version(void) {
+        fprintf(stderr, "\nPublic OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):\n");
+        fprintf(stderr, "\t%-10s\t%s\n", "name:", OpenSSL_version(OPENSSL_VERSION));
+        fprintf(stderr, "\t%-10s\t%s\n", "version:", OpenSSL_version(OPENSSL_VERSION_STRING));
+        fprintf(stderr, "\t%-10s\t%s\n", "full-version:", OpenSSL_version(OPENSSL_FULL_VERSION_STRING));
+        fprintf(stderr, "\t%-10s\t%s\n", "built-on:", OpenSSL_version(OPENSSL_BUILT_ON) + 10);
+        fprintf(stderr, "\n");
+}
+
 static void print_module_version(void) {
 
         OSSL_PROVIDER *prov = NULL;
         OSSL_PARAM params[4], *p = params;
         char *name = "", *vers = "", *build = "";
 
+        fprintf(stderr, "FIPS cryptographic Module details (fips.so):\n");
         prov = OSSL_PROVIDER_load(NULL, "fips");
         if (prov == NULL)
                 goto err;
@@ -147,8 +158,6 @@ static void print_module_version(void) {
         *p = OSSL_PARAM_construct_end();
         if (!OSSL_PROVIDER_get_params(prov, params))
                 goto err;
-
-        fprintf(stderr, "Module details:\n");
         if (OSSL_PARAM_modified(params))
                 fprintf(stderr, "\t%-10s\t%s\n", "name:", name);
         if (OSSL_PARAM_modified(params + 1))
@@ -161,14 +170,14 @@ static void print_module_version(void) {
 
         return;
  err:
-        fprintf(stderr, "Failed to retreive module version information\n");
+        fprintf(stderr, "\tFailed to retrieve cryptographic module version information\n");
 }
 
 
 int
 main(int argc, const char *argv[])
 {
-        int rc = EXIT_SUCCESS;
+	int rc = EXIT_SUCCESS;
 
 	fprintf(stderr, "Checking OpenSSL lifecycle assurance.\n");
 
@@ -190,9 +199,10 @@ main(int argc, const char *argv[])
 		}
 	}
 
+	print_base_version();
+	print_module_version();
 	if (rc == EXIT_SUCCESS) {
 		fprintf(stderr, "\nLifecycle assurance satisfied.\n");
-		print_module_version();
 	}
 
 	return rc;


### PR DESCRIPTION
When openssl tool is not available, one cannot easily find the runtime version
of libcrypto.so in addition to the runtime version of fips.so.

Add additional version information about the public API for
libcrypto.so/libssl.so.

New output is:

```
Checking OpenSSL lifecycle assurance.
*** Running check: FIPS module is available...
    HMAC : (Module_Integrity) : Pass
    SHA1 : (KAT_Digest) : Pass
    SHA2 : (KAT_Digest) : Pass
    SHA3 : (KAT_Digest) : Pass
    TDES : (KAT_Cipher) : Pass
    AES_GCM : (KAT_Cipher) : Pass
    AES_ECB_Decrypt : (KAT_Cipher) : Pass
    RSA : (KAT_Signature) :     RNG : (Continuous_RNG_Test) : Pass
Pass
    ECDSA : (PCT_Signature) : Pass
    DSA : (PCT_Signature) : Pass
    TLS13_KDF_EXTRACT : (KAT_KDF) : Pass
    TLS13_KDF_EXPAND : (KAT_KDF) : Pass
    TLS12_PRF : (KAT_KDF) : Pass
    PBKDF2 : (KAT_KDF) : Pass
    SSHKDF : (KAT_KDF) : Pass
    KBKDF : (KAT_KDF) : Pass
    HKDF : (KAT_KDF) : Pass
    SSKDF : (KAT_KDF) : Pass
    X963KDF : (KAT_KDF) : Pass
    X942KDF : (KAT_KDF) : Pass
    HASH : (DRBG) : Pass
    CTR : (DRBG) : Pass
    HMAC : (DRBG) : Pass
    DH : (KAT_KA) : Pass
    ECDH : (KAT_KA) : Pass
    RSA_Encrypt : (KAT_AsymmetricCipher) : Pass
    RSA_Decrypt : (KAT_AsymmetricCipher) : Pass
    RSA_Decrypt : (KAT_AsymmetricCipher) : Pass
    Running check: FIPS module is available... passed.
*** Running check: EVP_default_properties_is_fips_enabled returns true... passed.
*** Running check: verify unapproved cryptographic routines are not available by default (e.g. MD5)... passed.

Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
	name:     	OpenSSL 3.4.0 22 Oct 2024
	version:  	3.4.0
	full-version:	3.4.0
	built-on: 	Tue Nov 12 16:53:09 2024 UTC

FIPS cryptographic Module details (fips.so):
	name:     	OpenSSL FIPS Provider
	version:  	3.0.9
	build:    	3.0.9

Locate applicable CMVP certificates at
    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.9

Lifecycle assurance satisfied.
```

And for non-fips case:

```
Checking OpenSSL lifecycle assurance.
*** Running check: FIPS module is available...
    Running check: FIPS module is available... failed.
*** Running check: EVP_default_properties_is_fips_enabled returns true... failed.
*** Running check: verify unapproved cryptographic routines are not available by default (e.g. MD5)... failed.

Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
	name:     	OpenSSL 3.0.13 30 Jan 2024
	version:  	3.0.13
	full-version:	3.0.13
	built-on: 	Wed Feb  5 13:17:43 2025 UTC

FIPS cryptographic Module details (fips.so):
	Failed to retrieve cryptographic module version information
```
