### PR TITLE
module version

### DIFF
--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -166,7 +166,10 @@ static void print_module_version(void) {
                 fprintf(stderr, "\t%-10s\t%s\n", "build:", build);
 
         fprintf(stderr, "\nLocate applicable CMVP certificates at\n");
-        fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=%.5s\n", vers);
+        if (strncmp(vers, "3.1.2", 5) == 0)
+                fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985\n");
+        else
+                fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=%.5s\n", vers);
 
         return;
  err:


### PR DESCRIPTION
- **Print public API version information**
  When openssl tool is not available, one cannot easily find the runtime version
  of libcrypto.so in addition to the runtime version of fips.so.
  
  Add additional version information about the public API for
  libcrypto.so/libssl.so.
  
  New output is:
  
  ```
  Checking OpenSSL lifecycle assurance.
  *** Running check: FIPS module is available...
      HMAC : (Module_Integrity) : Pass
      SHA1 : (KAT_Digest) : Pass
      SHA2 : (KAT_Digest) : Pass
      SHA3 : (KAT_Digest) : Pass
      TDES : (KAT_Cipher) : Pass
      AES_GCM : (KAT_Cipher) : Pass
      AES_ECB_Decrypt : (KAT_Cipher) : Pass
      RSA : (KAT_Signature) :     RNG : (Continuous_RNG_Test) : Pass
  Pass
      ECDSA : (PCT_Signature) : Pass
      DSA : (PCT_Signature) : Pass
      TLS13_KDF_EXTRACT : (KAT_KDF) : Pass
      TLS13_KDF_EXPAND : (KAT_KDF) : Pass
      TLS12_PRF : (KAT_KDF) : Pass
      PBKDF2 : (KAT_KDF) : Pass
      SSHKDF : (KAT_KDF) : Pass
      KBKDF : (KAT_KDF) : Pass
      HKDF : (KAT_KDF) : Pass
      SSKDF : (KAT_KDF) : Pass
      X963KDF : (KAT_KDF) : Pass
      X942KDF : (KAT_KDF) : Pass
      HASH : (DRBG) : Pass
      CTR : (DRBG) : Pass
      HMAC : (DRBG) : Pass
      DH : (KAT_KA) : Pass
      ECDH : (KAT_KA) : Pass
      RSA_Encrypt : (KAT_AsymmetricCipher) : Pass
      RSA_Decrypt : (KAT_AsymmetricCipher) : Pass
      RSA_Decrypt : (KAT_AsymmetricCipher) : Pass
      Running check: FIPS module is available... passed.
  *** Running check: EVP_default_properties_is_fips_enabled returns true... passed.
  *** Running check: verify unapproved cryptographic routines are not available by default (e.g. MD5)... passed.
  
  Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
  	name:     	OpenSSL 3.4.0 22 Oct 2024
  	version:  	3.4.0
  	full-version:	3.4.0
  	built-on: 	Tue Nov 12 16:53:09 2024 UTC
  
  FIPS cryptographic Module details (fips.so):
  	name:     	OpenSSL FIPS Provider
  	version:  	3.0.9
  	build:    	3.0.9
  
  Locate applicable CMVP certificates at
      https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.9
  
  Lifecycle assurance satisfied.
  ```
  
  And for non-fips case:
  
  ```
  Checking OpenSSL lifecycle assurance.
  *** Running check: FIPS module is available...
      Running check: FIPS module is available... failed.
  *** Running check: EVP_default_properties_is_fips_enabled returns true... failed.
  *** Running check: verify unapproved cryptographic routines are not available by default (e.g. MD5)... failed.
  
  Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
  	name:     	OpenSSL 3.0.13 30 Jan 2024
  	version:  	3.0.13
  	full-version:	3.0.13
  	built-on: 	Wed Feb  5 13:17:43 2025 UTC
  
  FIPS cryptographic Module details (fips.so):
  	Failed to retrieve cryptographic module version information
  ```
  

- **Print custom search URL for the 3.1.2 module**
  Add custom URL printing for 3.1.2 module, because CMVP website doesn't list a
  software version for it yet. Thus search it by explicit certificate number.
  
  Request to update CMVP website with a software version listed has been
  requested.
  
  For 3.1.2 module the search urls now uses `&CertificateNumber=4985`.
  
  Whilst all others continue to use `&SoftwareVersions=$VERSION`.
  
  ```
  Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
  	name:     	OpenSSL 3.5.0 8 Apr 2025
  	version:  	3.5.0
  	full-version:	3.5.0
  	built-on: 	Tue Apr 22 11:15:50 2025 UTC
  
  FIPS cryptographic Module details (fips.so):
  	name:     	OpenSSL FIPS Provider
  	version:  	3.1.2
  	build:    	3.1.2
  
  Locate applicable CMVP certificates at
      https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985
  
  Lifecycle assurance satisfied.
  ```
  
  And existing modules will continue to be the same:
  
  ```
  Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
  	name:     	OpenSSL 3.5.0 8 Apr 2025
  	version:  	3.5.0
  	full-version:	3.5.0
  	built-on: 	Tue Apr 22 11:15:50 2025 UTC
  
  FIPS cryptographic Module details (fips.so):
  	name:     	Chainguard FIPS Provider for OpenSSL
  	version:  	3.4.0
  	build:    	3.4.0-r3
  
  Locate applicable CMVP certificates at
      https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.4.0
  ```
  