### PR TITLE
Print custom search URL for the 3.1.2 module

### DIFF
--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -166,7 +166,10 @@ static void print_module_version(void) {
                 fprintf(stderr, "\t%-10s\t%s\n", "build:", build);
 
         fprintf(stderr, "\nLocate applicable CMVP certificates at\n");
-        fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=%.5s\n", vers);
+        if (strncmp(vers, "3.1.2", 5) == 0)
+                fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985\n");
+        else
+                fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=%.5s\n", vers);
 
         return;
  err:


### PR DESCRIPTION
Add custom URL printing for 3.1.2 module, because CMVP website doesn't list a
software version for it yet. Thus search it by explicit certificate number.

Request to update CMVP website with a software version listed has been
requested.

For 3.1.2 module the search urls now uses `&CertificateNumber=4985`.

Whilst all others continue to use `&SoftwareVersions=$VERSION`.

```
Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
	name:     	OpenSSL 3.5.0 8 Apr 2025
	version:  	3.5.0
	full-version:	3.5.0
	built-on: 	Tue Apr 22 11:15:50 2025 UTC

FIPS cryptographic Module details (fips.so):
	name:     	OpenSSL FIPS Provider
	version:  	3.1.2
	build:    	3.1.2

Locate applicable CMVP certificates at
    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985

Lifecycle assurance satisfied.
```

And existing modules will continue to be the same:

```
Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
	name:     	OpenSSL 3.5.0 8 Apr 2025
	version:  	3.5.0
	full-version:	3.5.0
	built-on: 	Tue Apr 22 11:15:50 2025 UTC

FIPS cryptographic Module details (fips.so):
	name:     	Chainguard FIPS Provider for OpenSSL
	version:  	3.4.0
	build:    	3.4.0-r3

Locate applicable CMVP certificates at
    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.4.0
```
