### PR TITLE
Check for HMAC-MD5 instead of just MD5

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ Checking OpenSSL lifecycle assurance.
 *** Running check: FIPS module is available...
     Running check: FIPS module is available... failed.
 *** Running check: EVP_default_properties_is_fips_enabled returns true... failed.
-*** Running check: verify unapproved cryptographic routines are not available by default (e.g. MD5)... failed.
+*** Running check: verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)... failed.
+
+Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
+	name:     	OpenSSL 3.4.1 11 Feb 2025
+	version:  	3.4.1
+	full-version:	3.4.1
+	built-on: 	Thu Apr  3 08:48:37 2025 UTC
+
+FIPS cryptographic Module details (fips.so):
+	Failed to retrieve cryptographic module version information
 ```
 
 Example of systems using OpenSSL Project CMVP certificate:
@@ -83,7 +92,7 @@ Pass
     RSA_Decrypt : (KAT_AsymmetricCipher) : Pass
     Running check: FIPS module is available... passed.
 *** Running check: EVP_default_properties_is_fips_enabled returns true... passed.
-*** Running check: verify unapproved cryptographic routines are not available by default (e.g. MD5)... passed.
+*** Running check: verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)... passed.
 
 Lifecycle assurance satisfied.
 Module details:
@@ -130,7 +139,7 @@ Pass
     HMAC : (Module_Integrity) : Pass
     Running check: FIPS module is available... passed.
 *** Running check: EVP_default_properties_is_fips_enabled returns true... passed.
-*** Running check: verify unapproved cryptographic routines are not available by default (e.g. MD5)... passed.
+*** Running check: verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)... passed.
 
 Lifecycle assurance satisfied.
 Module details:

--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -66,13 +66,15 @@ test_fips_module_is_enabled(void)
 }
 
 static bool
-test_md5_not_available(void)
+test_hmac_md5_not_available(void)
 {
-	EVP_MD *md5 = NULL;
+	size_t outlen = 0;
 
-	md5 = EVP_MD_fetch(NULL, "MD5", NULL);
-	if (md5 != NULL)
+	unsigned char *hmac_md5 = EVP_Q_mac(NULL, "HMAC", NULL, "MD5", NULL, "12345678901234", 14, NULL, 0, NULL, 0, &outlen);
+	if (hmac_md5 != NULL) {
+		free(hmac_md5);
 		return false;
+	}
 
 	return true;
 }
@@ -89,9 +91,9 @@ static const struct test_ tests[] = {
 		.test_fn = test_fips_module_is_enabled,
 	},
 	{
-		.name = "verify unapproved cryptographic routines are not available by default (e.g. MD5)",
+		.name = "verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)",
 		.expected = true,
-		.test_fn = test_md5_not_available,
+		.test_fn = test_hmac_md5_not_available,
 	},
 };
 


### PR DESCRIPTION
MD5 is often used as a non-cryptographically secure CRC function. And thus
availability of MD5 is often fine.

What matters the most is that cryptographic functionality with MD5 is blocked,
such as HMAC, symmetric signature creation or verficiation, key derivation,
etc.

HMAC is the simpliest of them all, thus switch the unapproved algorithms check
to check for HMAC-MD5. This way even if MD5 digest is allowed, it is clear that
cryptographic protection with MD5 is blocked.
