### PR TITLE
Use ANSI Color and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@ to use its FIPS module.
 ## Caveats
 
 This tool can only detect whether or not OpenSSL is properly configured:
-applications and languages must be built to make use of libcrypto in order
-for the OpenSSL FIPS configuration to actually be useful.
+applications and languages must be built to make use of shared linked libcrypto
+in order for the OpenSSL FIPS configuration to actually be useful.
 
-This tool does not validate whether any other element in an overall
-delivered configuration is, or is not, FIPS 140-2/140-3 compliant.  It
-only tests whether OpenSSL is properly configured and making use of the
-FIPS module correctly.
+This tool does not validate whether any other element in an overall delivered
+configuration is, or is not, FIPS 140-3 compliant.  It only tests whether
+OpenSSL is properly configured and making use of the FIPS module correctly.
 
 ## Usage
 
-On Wolfi, simply install the `openssl-fips-test` package and run it.
+All Chainguard FIPS images ship `openssl-fips-test` preinstalled.
 
 On other systems, run `make` and `make install` as usual with whatever
 escalation tool you normally use.  You must have the OpenSSL development
@@ -34,119 +33,93 @@ used.
 It also retrieves FIPS module information and returns CMVP search URL where one
 should be able to find applicable certificates.
 
+It also provides a summary of available algorithms, which is useful to compare
+different CMVP modules and the algorithms they offer.
+
 ## Example output
 
-Uncertified systems will typically report this:
+Systems without a FIPS provider will typically report this:
 
 ```
+$ openssl-fips-test
 Checking OpenSSL lifecycle assurance.
-*** Running check: FIPS module is available...
-    Running check: FIPS module is available... failed.
-*** Running check: EVP_default_properties_is_fips_enabled returns true... failed.
-*** Running check: verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)... failed.
 
-Public OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):
-	name:     	OpenSSL 3.4.1 11 Feb 2025
-	version:  	3.4.1
-	full-version:	3.4.1
-	built-on: 	Thu Apr  3 08:48:37 2025 UTC
+	✗ Check FIPS cryptographic module is available... FAILED.
+	✗ Check FIPS approved only mode (EVP_default_properties_is_fips_enabled)... FAILED.
+	✗ Check non-approved algorithm blocked (HMAC-MD5)... FAILED.
 
-FIPS cryptographic Module details (fips.so):
-	Failed to retrieve cryptographic module version information
+Failed to retrieve cryptographic module version information
 ```
 
-Example of systems using OpenSSL Project CMVP certificate:
+Example of systems using OpenSSL Project FIPS provider:
 
 ```
-# ./openssl-fips-test
+$ openssl-fips-test
 Checking OpenSSL lifecycle assurance.
-*** Running check: FIPS module is available...
-    HMAC : (Module_Integrity) : Pass
-    SHA1 : (KAT_Digest) : Pass
-    SHA2 : (KAT_Digest) : Pass
-    SHA3 : (KAT_Digest) : Pass
-    TDES : (KAT_Cipher) : Pass
-    AES_GCM : (KAT_Cipher) : Pass
-    AES_ECB_Decrypt : (KAT_Cipher) : Pass
-    RSA : (KAT_Signature) :     RNG : (Continuous_RNG_Test) : Pass
-Pass
-    ECDSA : (PCT_Signature) : Pass
-    DSA : (PCT_Signature) : Pass
-    TLS13_KDF_EXTRACT : (KAT_KDF) : Pass
-    TLS13_KDF_EXPAND : (KAT_KDF) : Pass
-    TLS12_PRF : (KAT_KDF) : Pass
-    PBKDF2 : (KAT_KDF) : Pass
-    SSHKDF : (KAT_KDF) : Pass
-    KBKDF : (KAT_KDF) : Pass
-    HKDF : (KAT_KDF) : Pass
-    SSKDF : (KAT_KDF) : Pass
-    X963KDF : (KAT_KDF) : Pass
-    X942KDF : (KAT_KDF) : Pass
-    HASH : (DRBG) : Pass
-    CTR : (DRBG) : Pass
-    HMAC : (DRBG) : Pass
-    DH : (KAT_KA) : Pass
-    ECDH : (KAT_KA) : Pass
-    RSA_Encrypt : (KAT_AsymmetricCipher) : Pass
-    RSA_Decrypt : (KAT_AsymmetricCipher) : Pass
-    RSA_Decrypt : (KAT_AsymmetricCipher) : Pass
-    Running check: FIPS module is available... passed.
-*** Running check: EVP_default_properties_is_fips_enabled returns true... passed.
-*** Running check: verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)... passed.
 
-Lifecycle assurance satisfied.
-Module details:
+	✓ Self-test KAT_Integrity HMAC ... passed.
+	✓ Self-test Module_Integrity HMAC ... passed.
+	✓ Self-test KAT_Digest SHA1 ... passed.
+	✓ Self-test KAT_Digest SHA2 ... passed.
+	✓ Self-test KAT_Digest SHA3 ... passed.
+	✓ Self-test KAT_Cipher AES_GCM ... passed.
+	✓ Self-test KAT_Cipher AES_ECB_Decrypt ... passed.
+	✓ Self-test Continuous_RNG_Test RNG ... passed.
+	✓ Self-test KAT_Signature RSA ... passed.
+	✓ Self-test KAT_Signature ECDSA ... passed.
+	✓ Self-test KAT_Signature DSA ... passed.
+	✓ Self-test KAT_KDF TLS13_KDF_EXTRACT ... passed.
+	✓ Self-test KAT_KDF TLS13_KDF_EXPAND ... passed.
+	✓ Self-test KAT_KDF TLS12_PRF ... passed.
+	✓ Self-test KAT_KDF PBKDF2 ... passed.
+	✓ Self-test KAT_KDF SSHKDF ... passed.
+	✓ Self-test KAT_KDF KBKDF ... passed.
+	✓ Self-test KAT_KDF HKDF ... passed.
+	✓ Self-test KAT_KDF SSKDF ... passed.
+	✓ Self-test KAT_KDF X963KDF ... passed.
+	✓ Self-test KAT_KDF X942KDF ... passed.
+	✓ Self-test DRBG HASH ... passed.
+	✓ Self-test DRBG CTR ... passed.
+	✓ Self-test DRBG HMAC ... passed.
+	✓ Self-test KAT_KA DH ... passed.
+	✓ Self-test KAT_KA ECDH ... passed.
+	✓ Self-test KAT_AsymmetricCipher RSA_Encrypt ... passed.
+	✓ Self-test KAT_AsymmetricCipher RSA_Decrypt ... passed.
+	✓ Self-test KAT_AsymmetricCipher RSA_Decrypt ... passed.
+
+	✓ 29 out of 29 self-tests passed.
+	✓ Check FIPS cryptographic module is available... passed.
+	✓ Check FIPS approved only mode (EVP_default_properties_is_fips_enabled)... passed.
+	✓ Check non-approved algorithm blocked (HMAC-MD5)... passed.
+
+Digests available for non-security use as per FIPS 140-3 I.G. 2.4.A (fips=no):
+	✓ MD5
+	✓ SHA1
+
+Available approved algorithms for security purposes (fips=yes):
+	✗ MD5
+	✓ SHA-1
+	✓ SHA-2
+	✓ SHA-3
+	✓ DSA
+	✓ RSA
+	✓ ECDSA
+	✗ DetECDSA
+	✗ Ed25519
+	✗ ML-DSA
+	✗ SLH-DSA
+	✗ ML-KEM
+	✗ X25519MLKEM768
+	✗ SecP256r1MLKEM768
+
+Public OpenSSL API (libssl.so & libcrypto.so):
+	name:     	OpenSSL 3.6.0 1 Oct 2025
+	version:  	3.6.0
+
+FIPS cryptographic module provider details (fips.so):
 	name:     	OpenSSL FIPS Provider
-	version:  	3.0.9
-	build:    	3.0.9
+	version:  	3.1.2
+	build:    	3.1.2
 
-Locate applicable CMVP certificates at
-    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.9
-```
-
-Example output on Ubuntu Pro FIPS instance:
-
-```
-./openssl-fips-test
-Checking OpenSSL lifecycle assurance.
-*** Running check: FIPS module is available...
-    SHA1 : (KAT_Digest) : Pass
-    SHA2 : (KAT_Digest) : Pass
-    SHA3 : (KAT_Digest) : Pass
-    AES_GCM : (KAT_Cipher) : Pass
-    AES_ECB_Decrypt : (KAT_Cipher) : Pass
-    RSA : (KAT_Signature) :     RNG : (Continuous_RNG_Test) : Pass
-    RNG : (Continuous_RNG_Test) : Pass
-    RNG : (Continuous_RNG_Test) : Pass
-Pass
-    ECDSA : (KAT_Signature) : Pass
-    ECDSA : (KAT_Signature) : Pass
-    TLS13_KDF_EXTRACT : (KAT_KDF) : Pass
-    TLS13_KDF_EXPAND : (KAT_KDF) : Pass
-    TLS12_PRF : (KAT_KDF) : Pass
-    PBKDF2 : (KAT_KDF) : Pass
-    SSHKDF : (KAT_KDF) : Pass
-    KBKDF : (KAT_KDF) : Pass
-    HKDF : (KAT_KDF) : Pass
-    SSKDF : (KAT_KDF) : Pass
-    X963KDF : (KAT_KDF) : Pass
-    X942KDF : (KAT_KDF) : Pass
-    HASH : (DRBG) : Pass
-    CTR : (DRBG) : Pass
-    HMAC : (DRBG) : Pass
-    DH : (KAT_KA) : Pass
-    ECDH : (KAT_KA) : Pass
-    HMAC : (Module_Integrity) : Pass
-    Running check: FIPS module is available... passed.
-*** Running check: EVP_default_properties_is_fips_enabled returns true... passed.
-*** Running check: verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)... passed.
-
-Lifecycle assurance satisfied.
-Module details:
-	name:     	Ubuntu 22.04 OpenSSL Cryptographic Module
-	version:  	3.0.5-0ubuntu0.1+Fips2.1
-	build:    	3.0.5-0ubuntu0.1+Fips2.1
-
-Locate applicable CMVP certificates at
-    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=3.0.5
+Locate applicable CMVP certificate(s) at: CMVP #4985
 ```

--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -30,10 +30,38 @@ struct test_ {
 	const bool (*test_fn)(void);
 };
 
+struct digest_ {
+	const char *name;
+	const bool dissallowed;
+	const bool legacy;
+};
+
+struct feature_ {
+	const char *fetch;
+	const char *name;
+};
+
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(*x))
+
+#define BOLD_RED "\x1B[0;1;31m"
+#define BOLD_GREEN "\x1B[0;1;32m"
+#define RESET "\x1B[0m"
+
+#define OSC_8_START "\033]8;;"
+#define OSC_8_END "\033\\"
+
+#define FAILED (BOLD_RED " FAILED" RESET ".\n")
+#define PASSED (BOLD_GREEN " passed" RESET ".\n")
+
+#define RED_CROSS (BOLD_RED "✗ " RESET)
+#define GREEN_CHECK (BOLD_GREEN "✓ " RESET)
+#define GREEN_CROSS (BOLD_GREEN "✗ " RESET)
 
 int selftest_passes = 0;
 int selftest_failures = 0;
+int selftest_total = 0;
+int detecdsa = 0;
+
 static bool
 test_fips_module_is_available(void)
 {
@@ -43,13 +71,17 @@ test_fips_module_is_available(void)
 
 	int rc = OSSL_PROVIDER_available(ctx, "fips");
 
-	fprintf(stderr, "    Running check: FIPS module is available...");
-
 	if (!rc)
 		return false;
 
 	if (selftest_passes == 0)
 		return false;
+
+	fprintf(stderr, "\n");
+	fprintf(stderr, "\t");
+	fprintf(stderr, GREEN_CHECK);
+	fprintf(stderr, "%i out of %i self-tests", selftest_passes, selftest_passes+selftest_failures);
+	fprintf(stderr, PASSED);
 
 	return (selftest_failures == 0);
 }
@@ -81,103 +113,292 @@ test_hmac_md5_not_available(void)
 
 static const struct test_ tests[] = {
 	{
-		.name = "FIPS module is available",
+		.name = "Check FIPS cryptographic module is available...",
 		.expected = true,
 		.test_fn = test_fips_module_is_available,
 	},
 	{
-		.name = "EVP_default_properties_is_fips_enabled returns true",
+		.name = "Check FIPS approved only mode (EVP_default_properties_is_fips_enabled)...",
 		.expected = true,
 		.test_fn = test_fips_module_is_enabled,
 	},
 	{
-		.name = "verify unapproved cryptographic routines are not available by default (e.g. HMAC-MD5)",
+		.name = "Check non-approved algorithm blocked (HMAC-MD5)...",
 		.expected = true,
 		.test_fn = test_hmac_md5_not_available,
 	},
 };
 
+static const struct digest_ non_approved_digests[] = {
+	{
+		.name = "MD5",
+	},
+	{
+		.name = "SHA1",
+	},
+};
+
+static const struct feature_ digest_features[] = {
+	{
+		.fetch = "MD5",
+		.name = "MD5",
+	},
+	{
+		.fetch = "SHA1",
+		.name = "SHA-1",
+	},
+	{
+		.fetch = "SHA2-256",
+		.name = "SHA-2",
+	},
+	{
+		.fetch = "SHA3-256",
+		.name = "SHA-3",
+	},
+};
+
+static const struct feature_ signature_features[] = {
+	{
+		.fetch = "DSA",
+		.name = "DSA",
+	},
+	{
+		.fetch = "RSA",
+		.name = "RSA",
+	},
+	{
+		.fetch = "ECDSA",
+		.name = "ECDSA",
+	},
+	{
+		.fetch = "ED25519",
+		.name = "Ed25519",
+	},
+	{
+		.fetch = "ECDSA",
+		.name = "DetECDSA",
+	},
+	{
+		.fetch = "ML-DSA-65",
+		.name = "ML-DSA",
+	},
+	{
+		.fetch = "SLH-DSA-SHAKE-128s",
+		.name = "SLH-DSA",
+	},
+};
+
+static const struct feature_ kem_features[] = {
+	{
+		.fetch = "ML-KEM-768",
+		.name = "ML-KEM",
+	},
+	{
+		.fetch = "X25519MLKEM768",
+		.name = "X25519MLKEM768",
+	},
+	{
+		.fetch = "SecP256r1MLKEM768",
+		.name = "SecP256r1MLKEM768",
+	},
+};
+
+
 static int self_test_events(const OSSL_PARAM params[], void *arg)
 {
-        const OSSL_PARAM *p = NULL;
-        const char *phase = NULL, *type = NULL, *desc = NULL;
+	const OSSL_PARAM *p = NULL;
+	const char *phase = NULL, *type = NULL, *desc = NULL;
 
-        p = OSSL_PARAM_locate_const(params, OSSL_PROV_PARAM_SELF_TEST_PHASE);
-        if (p == NULL || p->data_type != OSSL_PARAM_UTF8_STRING)
-                goto err;
-        phase = (const char *)p->data;
+	p = OSSL_PARAM_locate_const(params, OSSL_PROV_PARAM_SELF_TEST_PHASE);
+	if (p == NULL || p->data_type != OSSL_PARAM_UTF8_STRING)
+		goto err;
+	phase = (const char *)p->data;
 
-        p = OSSL_PARAM_locate_const(params, OSSL_PROV_PARAM_SELF_TEST_DESC);
-        if (p == NULL || p->data_type != OSSL_PARAM_UTF8_STRING)
-                goto err;
-        desc = (const char *)p->data;
+	if (strcmp(phase, OSSL_SELF_TEST_PHASE_PASS) != 0
+	    && strcmp(phase, OSSL_SELF_TEST_PHASE_FAIL) != 0) {
+		return true;
+	}
 
-        p = OSSL_PARAM_locate_const(params, OSSL_PROV_PARAM_SELF_TEST_TYPE);
-        if (p == NULL || p->data_type != OSSL_PARAM_UTF8_STRING)
-                goto err;
-        type = (const char *)p->data;
+	p = OSSL_PARAM_locate_const(params, OSSL_PROV_PARAM_SELF_TEST_DESC);
+	if (p == NULL || p->data_type != OSSL_PARAM_UTF8_STRING)
+		goto err;
+	desc = (const char *)p->data;
 
-        if (strcmp(phase, OSSL_SELF_TEST_PHASE_START) == 0)
-                fprintf(stderr, "    %s : (%s) : ", desc, type);
-        else if (strcmp(phase, OSSL_SELF_TEST_PHASE_PASS) == 0) {
-                fprintf(stderr, "%s\n", phase);
-                selftest_passes++;
-        } else if (strcmp(phase, OSSL_SELF_TEST_PHASE_FAIL) == 0) {
-                fprintf(stderr, "%s\n", phase);
-                selftest_failures++;
-        }
+	p = OSSL_PARAM_locate_const(params, OSSL_PROV_PARAM_SELF_TEST_TYPE);
+	if (p == NULL || p->data_type != OSSL_PARAM_UTF8_STRING)
+		goto err;
+	type = (const char *)p->data;
 
-        return true;
+	if (strcmp(phase, OSSL_SELF_TEST_PHASE_PASS) == 0) {
+		fprintf(stderr, "\t");
+		fprintf(stderr, GREEN_CHECK);
+		fprintf(stderr, "Self-test %s %s ...", type, desc);
+		fprintf(stderr, PASSED);
+		selftest_passes++;
+                selftest_total++;
+		if (strcmp(desc, "DetECDSA") == 0) {
+			detecdsa = 1;
+		}
+	} else if (strcmp(phase, OSSL_SELF_TEST_PHASE_FAIL) == 0) {
+		fprintf(stderr, "\t");
+		fprintf(stderr, RED_CROSS);
+		fprintf(stderr, "Self-test %s %s ...", type, desc);
+		fprintf(stderr, FAILED);
+		selftest_failures++;
+                selftest_total++;
+	}
+
+	return true;
 
  err:
-        selftest_failures++;
-        return false;
+	selftest_failures++;
+	return false;
+}
+
+static void print_non_security_digests(void) {
+	EVP_MD *digest = NULL;
+
+	fprintf(stderr, "\nDigests available for non-security use as per FIPS 140-3 I.G. 2.4.A (fips=no):\n");
+
+	for (size_t i = 0; i < ARRAY_SIZE(non_approved_digests); i++)
+	{
+		digest = EVP_MD_fetch(NULL, non_approved_digests[i].name, "?fips=no");
+		fprintf(stderr, "\t");
+		if (digest != NULL) {
+
+			fprintf(stderr, GREEN_CHECK);
+			fprintf(stderr, " %s", non_approved_digests[i].name);
+			EVP_MD_free(digest);
+			digest = NULL;
+		} else {
+			fprintf(stderr, "\t");
+			fprintf(stderr, RED_CROSS);
+			fprintf(stderr, " %s", non_approved_digests[i].name);
+			fprintf(stderr, "- expect failures with all public cloud SDKs");
+		}
+		fprintf(stderr, "\n");
+	}
+}
+
+static void print_security_features(void) {
+	EVP_MD *digest = NULL;
+        EVP_SIGNATURE *signature = NULL;
+        EVP_KEM *kem = NULL;
+
+	fprintf(stderr, "\nAvailable approved algorithms for security purposes (fips=yes):\n");
+
+	for (size_t i = 0; i < ARRAY_SIZE(digest_features); i++)
+	{
+		digest = EVP_MD_fetch(NULL, digest_features[i].fetch, "fips=yes");
+		fprintf(stderr, "\t");
+		if (digest != NULL) {
+			fprintf(stderr, GREEN_CHECK);
+			fprintf(stderr, "%s", digest_features[i].name);
+			EVP_MD_free(digest);
+			digest = NULL;
+		} else {
+			fprintf(stderr, "✗ ");
+			fprintf(stderr, "%s", digest_features[i].name);
+		}
+		fprintf(stderr, "\n");
+	}
+	for (size_t i = 0; i < ARRAY_SIZE(signature_features); i++)
+	{
+		signature = EVP_SIGNATURE_fetch(NULL, signature_features[i].fetch, "fips=yes");
+		fprintf(stderr, "\t");
+		if (strcmp(signature_features[i].name, "DetECDSA") == 0
+		    && detecdsa == 0) {
+			EVP_SIGNATURE_free(signature);
+			signature = NULL;
+		}
+		if (signature != NULL) {
+			fprintf(stderr, GREEN_CHECK);
+			fprintf(stderr, "%s", signature_features[i].name);
+			EVP_SIGNATURE_free(signature);
+			signature = NULL;
+		} else {
+			fprintf(stderr, "✗ ");
+			fprintf(stderr, "%s", signature_features[i].name);
+		}
+		fprintf(stderr, "\n");
+	}
+	for (size_t i = 0; i < ARRAY_SIZE(kem_features); i++)
+	{
+		kem = EVP_KEM_fetch(NULL, kem_features[i].fetch, "fips=yes");
+		fprintf(stderr, "\t");
+		if (kem != NULL) {
+			fprintf(stderr, GREEN_CHECK);
+			fprintf(stderr, "%s", kem_features[i].name);
+			EVP_KEM_free(kem);
+			kem = NULL;
+		} else {
+			fprintf(stderr, "✗ ");
+			fprintf(stderr, "%s", kem_features[i].name);
+		}
+		fprintf(stderr, "\n");
+	}
 }
 
 static void print_base_version(void) {
-        fprintf(stderr, "\nPublic OpenSSL API for TLS and cryptographic routines (libssl.so & libcrypto.so):\n");
-        fprintf(stderr, "\t%-10s\t%s\n", "name:", OpenSSL_version(OPENSSL_VERSION));
-        fprintf(stderr, "\t%-10s\t%s\n", "version:", OpenSSL_version(OPENSSL_VERSION_STRING));
-        fprintf(stderr, "\t%-10s\t%s\n", "full-version:", OpenSSL_version(OPENSSL_FULL_VERSION_STRING));
-        fprintf(stderr, "\t%-10s\t%s\n", "built-on:", OpenSSL_version(OPENSSL_BUILT_ON) + 10);
-        fprintf(stderr, "\n");
+	fprintf(stderr, "\nPublic OpenSSL API (libssl.so & libcrypto.so):\n");
+	fprintf(stderr, "\t%-10s\t%s\n", "name:", OpenSSL_version(OPENSSL_VERSION));
+	fprintf(stderr, "\t%-10s\t%s\n", "version:", OpenSSL_version(OPENSSL_VERSION_STRING));
+	//fprintf(stderr, "\t%-10s\t%s\n", "full-version:", OpenSSL_version(OPENSSL_FULL_VERSION_STRING));
+	//fprintf(stderr, "\t%-10s\t%s\n", "built-on:", OpenSSL_version(OPENSSL_BUILT_ON) + 10);
+	fprintf(stderr, "\n");
 }
 
 static void print_module_version(void) {
 
-        OSSL_PROVIDER *prov = NULL;
-        OSSL_PARAM params[4], *p = params;
-        char *name = "", *vers = "", *build = "";
+	OSSL_PROVIDER *prov = NULL;
+	OSSL_PARAM params[4], *p = params;
+	char *name = "", *vers = "", *build = "";
 
-        fprintf(stderr, "FIPS cryptographic Module details (fips.so):\n");
-        prov = OSSL_PROVIDER_load(NULL, "fips");
-        if (prov == NULL)
-                goto err;
+	fprintf(stderr, "FIPS cryptographic module provider details (fips.so):\n");
+	prov = OSSL_PROVIDER_load(NULL, "fips");
+	if (prov == NULL)
+		goto err;
 
-        *p++ = OSSL_PARAM_construct_utf8_ptr(OSSL_PROV_PARAM_NAME, &name, sizeof(name));
-        *p++ = OSSL_PARAM_construct_utf8_ptr(OSSL_PROV_PARAM_VERSION, &vers, sizeof(vers));
-        *p++ = OSSL_PARAM_construct_utf8_ptr(OSSL_PROV_PARAM_BUILDINFO, &build, sizeof(build));
-        *p = OSSL_PARAM_construct_end();
-        if (!OSSL_PROVIDER_get_params(prov, params))
-                goto err;
-        if (OSSL_PARAM_modified(params))
-                fprintf(stderr, "\t%-10s\t%s\n", "name:", name);
-        if (OSSL_PARAM_modified(params + 1))
-                fprintf(stderr, "\t%-10s\t%s\n", "version:", vers);
-        if (OSSL_PARAM_modified(params + 2))
-                fprintf(stderr, "\t%-10s\t%s\n", "build:", build);
+	*p++ = OSSL_PARAM_construct_utf8_ptr(OSSL_PROV_PARAM_NAME, &name, sizeof(name));
+	*p++ = OSSL_PARAM_construct_utf8_ptr(OSSL_PROV_PARAM_VERSION, &vers, sizeof(vers));
+	*p++ = OSSL_PARAM_construct_utf8_ptr(OSSL_PROV_PARAM_BUILDINFO, &build, sizeof(build));
+	*p = OSSL_PARAM_construct_end();
+	if (!OSSL_PROVIDER_get_params(prov, params))
+		goto err;
+	if (OSSL_PARAM_modified(params))
+		fprintf(stderr, "\t%-10s\t%s\n", "name:", name);
+	if (OSSL_PARAM_modified(params + 1))
+		fprintf(stderr, "\t%-10s\t%s\n", "version:", vers);
+	if (OSSL_PARAM_modified(params + 2))
+		fprintf(stderr, "\t%-10s\t%s\n", "build:", build);
 
-        fprintf(stderr, "\nLocate applicable CMVP certificates at\n");
-        if (strncmp(vers, "3.1.2", 5) == 0)
-                fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985\n");
-        else
-                fprintf(stderr, "    https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=%.5s\n", vers);
-
-        return;
+	fprintf(stderr, "\nLocate applicable CMVP certificate(s) at: ");
+	if (strncmp(vers, "3.1.2", 5) == 0)
+		fprintf(stderr, "%s%s%s%s%s%s%s\n",
+                        OSC_8_START,
+                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985",
+                        OSC_8_END,
+                        "CMVP #4985",
+                        OSC_8_START,
+                        "",
+                        OSC_8_END
+                );
+	else
+		fprintf(stderr, "%s%s%.5s%s%s%s%s%s\n",
+                        OSC_8_START,
+                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=",
+                        vers,
+                        OSC_8_END,
+                        "CMVP Search",
+                        OSC_8_START,
+                        "",
+                        OSC_8_END
+                );
+	return;
  err:
-        fprintf(stderr, "\tFailed to retrieve cryptographic module version information\n");
+	fprintf(stderr, BOLD_RED);
+	fprintf(stderr, "\tFailed to retrieve cryptographic module version information\n");
 }
-
 
 int
 main(int argc, const char *argv[])
@@ -190,24 +411,37 @@ main(int argc, const char *argv[])
 
 	for (size_t i = 0; i < ARRAY_SIZE(tests); i++)
 	{
-		fprintf(stderr, "*** Running check: %s...", tests[i].name);
-
 		bool ret = tests[i].test_fn();
+
 		if (ret != tests[i].expected)
 		{
-			fprintf(stderr, " failed.\n");
+			fprintf(stderr, "\t");
+			fprintf(stderr, RED_CROSS);
+			fprintf(stderr, "%s", tests[i].name);
+			fprintf(stderr, FAILED);
 			rc = EXIT_FAILURE;
 		}
 		else
 		{
-			fprintf(stderr, " passed.\n");
+			fprintf(stderr, "\t");
+			fprintf(stderr, GREEN_CHECK);
+			fprintf(stderr, "%s", tests[i].name);
+			fprintf(stderr, PASSED);
 		}
 	}
 
-	print_base_version();
-	print_module_version();
 	if (rc == EXIT_SUCCESS) {
-		fprintf(stderr, "\nLifecycle assurance satisfied.\n");
+		print_non_security_digests();
+		//print_security_digests();
+                print_security_features();
+		print_base_version();
+		print_module_version();
+		fprintf(stderr, "\n");
+	} else {
+		fprintf(stderr, BOLD_RED);
+		fprintf(stderr, "\nFailed to retrieve cryptographic module version information");
+		fprintf(stderr, RESET);
+		fprintf(stderr, "\n");
 	}
 
 	return rc;


### PR DESCRIPTION
Use escape codes to add color, bold, URLs. This makes the output more fancy.
Also add output of supported algorithms, to be able to clearly show differences
between 3.1, 3.4 and 3.6 modules.
