### PR TITLE
Update openssl-fips-test tool for 3.1.2 rebrand  support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 PROG = openssl-fips-test
 SRCS = openssl-fips-test.c
-CFLAGS += -Wall -std=gnu1x -O2 -D_FORTIFY_SOURCE=3
-CFLAGS += $(shell pkg-config --cflags openssl)
+CFLAGS += -Wall -std=gnu1x -O3 -D_FORTIFY_SOURCE=3
+CFLAGS += $(shell pkg-config --cflags libcrypto)
 INSTALL ?= install
-LIBS = $(shell pkg-config --libs openssl)
+LIBS = $(shell pkg-config --libs libcrypto)
 OBJS = ${SRCS:.c=.o}
 
 all: ${PROG}

--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -378,7 +378,7 @@ static void print_module_version(void) {
             && strncmp(vers, "3.1.2", 5) == 0) {
 		fprintf(stderr, "%s%s%s%s%s%s%s\n",
                         OSC_8_START,
-                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=5102",
+                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5102",
                         OSC_8_END,
                         "CMVP #5102",
                         OSC_8_START,
@@ -391,7 +391,7 @@ static void print_module_version(void) {
             && strncmp(vers, "3.1.2", 5) == 0) {
 		fprintf(stderr, "%s%s%s%s%s%s%s\n",
                         OSC_8_START,
-                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985",
+                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4985",
                         OSC_8_END,
                         "CMVP #4985",
                         OSC_8_START,

--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -373,7 +373,22 @@ static void print_module_version(void) {
 		fprintf(stderr, "\t%-10s\t%s\n", "build:", build);
 
 	fprintf(stderr, "\nLocate applicable CMVP certificate(s) at: ");
-	if (strncmp(vers, "3.1.2", 5) == 0)
+        /* NIST CMVP search still does not have a version search working */
+        if (strcmp(name, "Chainguard FIPS Provider for OpenSSL") == 0
+            && strncmp(vers, "3.1.2", 5) == 0) {
+		fprintf(stderr, "%s%s%s%s%s%s%s\n",
+                        OSC_8_START,
+                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=5102",
+                        OSC_8_END,
+                        "CMVP #5102",
+                        OSC_8_START,
+                        "",
+                        OSC_8_END
+                );
+                return;
+        }
+        if (strcmp(name, "OpenSSL FIPS Provider") == 0
+            && strncmp(vers, "3.1.2", 5) == 0) {
 		fprintf(stderr, "%s%s%s%s%s%s%s\n",
                         OSC_8_START,
                         "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&CertificateNumber=4985",
@@ -383,17 +398,19 @@ static void print_module_version(void) {
                         "",
                         OSC_8_END
                 );
-	else
-		fprintf(stderr, "%s%s%.5s%s%s%s%s%s\n",
-                        OSC_8_START,
-                        "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=",
-                        vers,
-                        OSC_8_END,
-                        "CMVP Search",
-                        OSC_8_START,
-                        "",
-                        OSC_8_END
-                );
+                return;
+        }
+
+        fprintf(stderr, "%s%s%.5s%s%s%s%s%s\n",
+                OSC_8_START,
+                "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&ModuleName=OpenSSL&CertificateStatus=Active&ValidationYear=0&SoftwareVersions=",
+                vers,
+                OSC_8_END,
+                "CMVP Search",
+                OSC_8_START,
+                "",
+                OSC_8_END
+        );
 	return;
  err:
 	fprintf(stderr, BOLD_RED);


### PR DESCRIPTION
- **Only libcrypto is needed so far**
  

- **Add new Chainguard rebrand certificate**
  

- **For direct certs, use direct URL**
  