### PR TITLE
Fix clang compatibility in struct definitions

### DIFF
--- a/openssl-fips-test.c
+++ b/openssl-fips-test.c
@@ -27,7 +27,7 @@
 struct test_ {
 	const char *name;
 	const bool expected;
-	const bool (*test_fn)(void);
+	bool (*test_fn)(void);
 };
 
 struct digest_ {


### PR DESCRIPTION
# Summary

Fix clang compilation error caused by incompatible function pointer types in `struct test_`
  
#  Details

  The test_fn member was declared as const bool (*test_fn)(void), but the actual
   test functions return bool. Clang strictly enforces function pointer type
  compatibility and rejects this mismatch with
  -Wincompatible-function-pointer-types. Since const on scalar return types is
  meaningless, removing it is the correct fix.

  Error before fix:
  openssl-fips-test.c:118:14: error: incompatible function pointer types
  initializing 'const bool (*)(void)' with an expression of type 'bool (void)'
  
  ```
  make                                                                      
cc -Wall -std=gnu1x -O3 -D_FORTIFY_SOURCE=3 -I/opt/homebrew/Cellar/openssl@3/3.6.0/include   -c -o openssl-fips-test.o openssl-fips-test.c
openssl-fips-test.c:118:14: error: incompatible function pointer types initializing 'const bool (*)(void)' with an expression of type 'bool (void)' [-Wincompatible-function-pointer-types]
  118 |                 .test_fn = test_fips_module_is_available,
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
openssl-fips-test.c:123:14: error: incompatible function pointer types initializing 'const bool (*)(void)' with an expression of type 'bool (void)' [-Wincompatible-function-pointer-types]
  123 |                 .test_fn = test_fips_module_is_enabled,
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
openssl-fips-test.c:128:14: error: incompatible function pointer types initializing 'const bool (*)(void)' with an expression of type 'bool (void)' [-Wincompatible-function-pointer-types]
  128 |                 .test_fn = test_hmac_md5_not_available,
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.
make: *** [openssl-fips-test.o] Error 1
```

## Test plan

  - Verify project compiles successfully with clang on macOS
  - Verify project compiles successfully with gcc on Linux